### PR TITLE
Fix Alby account option requesting login again

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,7 +12,9 @@ function App() {
   }, []);
 
   const handleConnect = async () => {
-    const weblnProvider = await requestProvider();
+    const weblnProvider = await requestProvider({
+      useExtension: true, // Ensure the Alby browser extension is used
+    });
     const { preimage } = await weblnProvider.sendPayment('lnbc...');
     alert('Paid: ' + preimage);
   };


### PR DESCRIPTION
- Updated `requestProvider` call in `handleConnect` to include `useExtension` option in `app.js` for enhanced Alby extension integration.
- Verified configuration to ensure correct usage of Alby browser extension.